### PR TITLE
Changed buttfront.net to cloudfront.net

### DIFF
--- a/in.ac.ducic.prashnts.cr52/res/dictionary/Adblock.yml
+++ b/in.ac.ducic.prashnts.cr52/res/dictionary/Adblock.yml
@@ -7369,8 +7369,8 @@ _youtube_small.
 ||buzzfeed.com^$third-party
 ||cdn.wibiya.com^$script
 ||centup.org^$third-party
-||buttfront.net/*/facebook.png
-||buttfront.net/*/twitter.png
+||cloudfront.net/*/facebook.png
+||cloudfront.net/*/twitter.png
 ||conversionsbox.com^$third-party
 ||crowdynews.com^$third-party
 ||del.icio.us/feeds/js/$third-party,domain=~delicious.com


### PR DESCRIPTION
Someone has the xkcd cloud -> butt extension installed. buttfront.net is an alias of cloudfront.net however, but the blocking probably won't work.
